### PR TITLE
Fix haploxy version to 1.5.8-3+deb8u2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7.10-slim
 
 ENV MARATHON_VERSION 0.10.0
-ENV HAPROXY_VERSION 1.5.8-3
+ENV HAPROXY_VERSION 1.5.8-3+deb8u2
 
 # install haproxy and mercurial and marathon code
 RUN apt-get update -qq && \


### PR DESCRIPTION
fix #1 
